### PR TITLE
Allow duplicate options with same value.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tom-select",
+  "name": "@gravitywiz/tom-select",
   "keywords": [
     "select",
     "ui",

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -22,7 +22,7 @@ export default {
 	preload: null,
 	allowEmptyOption: false,
 	//closeAfterSelect: false,
-
+	allowDuplicates: false,
 	loadThrottle: 300,
 	loadingClass: 'loading',
 

--- a/src/getSettings.ts
+++ b/src/getSettings.ts
@@ -40,12 +40,14 @@ export default function getSettings(
 		optgroups: TomOption[];
 		items: string[];
 		maxItems: null | number;
+		allowDuplicates: null | boolean,
 	} = {
 		placeholder,
 		options: [],
 		optgroups: [],
 		items: [],
 		maxItems: null,
+		allowDuplicates: false,
 	};
 
 	/**

--- a/src/getSettings.ts
+++ b/src/getSettings.ts
@@ -79,11 +79,27 @@ export default function getSettings(
 				return;
 			}
 
+			// if duplicates are allowed, make id (value) as id + text label
+			if (settings.allowDuplicates) {
+				const option_data = readData(option);
+				option_data[field_label] =
+					option_data[field_label] || option.textContent;
+				option_data[field_value] = option_data[field_value] || value;
+				option_data[field_disabled] =
+					option_data[field_disabled] || option.disabled;
+				option_data[field_optgroup] =
+					option_data[field_optgroup] || group;
+				option_data.id += '_' + option.text;
+				option_data.$option = option;
+				
+				optionsMap[value] = option_data;
+				options.push(option_data);
+			}
 			// if the option already exists, it's probably been
 			// duplicated in another optgroup. in this case, push
 			// the current group to the "optgroup" property on the
 			// existing option so that it's rendered in both places.
-			if (optionsMap.hasOwnProperty(value)) {
+			else if (optionsMap.hasOwnProperty(value)) {
 				if (group) {
 					const arr = optionsMap[value][field_optgroup];
 					if (!arr) {


### PR DESCRIPTION
## Context

https://github.com/orchidjs/tom-select/discussions/395
https://github.com/orchidjs/tom-select/issues/592

## Summary

To allow duplicate options with the same value. 

```html
<div><select id="ex" autocomplete="off" multiple>
      <option value="c1">Cool1</option>
      <option value="c1">Cool2</option>
      <option value="c3">Cool3</option>
</select></div>
```
Right now with default configuration, Cool2 option will be omitted/removed by tom-select since it has the same value with Cool1.

This update adds an `allowDuplicates` option to ensure both Cool1 and cool2 be rendered with TomSelect.