### PR TITLE
Fixed issue where incorrect value would sometimes get passed to `updateOption` due to always using the `value` key.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "dist/types/tom-select.complete.d.ts",
   "description": "Tom Select is a versatile and dynamic <select> UI control. Forked from Selectize.js to provide a framework agnostic autocomplete widget with native-feeling keyboard navigation, it's useful for tagging, contact lists, country selectors, etc.",
   "homepage": "https://tom-select.js.org",
-  "version": "0.0.1",
+  "version": "0.0.2-beta.0",
   "files": [
     "/dist",
     "/src"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "dist/types/tom-select.complete.d.ts",
   "description": "Tom Select is a versatile and dynamic <select> UI control. Forked from Selectize.js to provide a framework agnostic autocomplete widget with native-feeling keyboard navigation, it's useful for tagging, contact lists, country selectors, etc.",
   "homepage": "https://tom-select.js.org",
-  "version": "0.0.2-beta.0",
+  "version": "0.0.2",
   "files": [
     "/dist",
     "/src"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "dist/types/tom-select.complete.d.ts",
   "description": "Tom Select is a versatile and dynamic <select> UI control. Forked from Selectize.js to provide a framework agnostic autocomplete widget with native-feeling keyboard navigation, it's useful for tagging, contact lists, country selectors, etc.",
   "homepage": "https://tom-select.js.org",
-  "version": "2.2.2",
+  "version": "0.0.1",
   "files": [
     "/dist",
     "/src"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tom-select",
+  "name": "@gravitywiz/tom-select",
   "keywords": [
     "select",
     "ui",

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -476,12 +476,9 @@ export default class TomSelect extends MicroPlugin(MicroEvent) {
 
 	setupMutationObserver(node: HTMLElement) {
 		this.mutationObserver = new MutationObserver((mutations, observer) => {
-
-			// console.log('mutation', this.options);
-
 			// TODO look into performance of this to avoid running this on ever single mutation.
 			iterate(this.options, (option: TomOption) => {
-				this.updateOption(option.text, option);
+				this.updateOption(option[this.settings.valueField], option);
 			});
 
 			if (this.input.disabled !== this.isDisabled) {

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1922,6 +1922,11 @@ export default class TomSelect extends MicroPlugin(MicroEvent) {
 		if (option) {
 			if (self.dropdown_content.contains(option)) {
 				const option_new = self._render('option', data);
+
+				if (self.items.includes(value_new)) {
+					option_new.classList.add('selected');
+				}
+
 				replaceNode(option, option_new);
 
 				if (self.activeOption === option) {


### PR DESCRIPTION
## Context

https://secure.helpscout.net/conversation/2499159955/60820?folderId=6987275

## Summary

Sometimes, the incorrect value was getting passed into the `updateOption()` method due to passing in the hardcoded `option.value`. Instead, we need to dynamically use the key defined in `settings.valueField`.

