### PR TITLE
Fix issue where lazy loaded options would not get added to the original input element.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "dist/types/tom-select.complete.d.ts",
   "description": "Tom Select is a versatile and dynamic <select> UI control. Forked from Selectize.js to provide a framework agnostic autocomplete widget with native-feeling keyboard navigation, it's useful for tagging, contact lists, country selectors, etc.",
   "homepage": "https://tom-select.js.org",
-  "version": "0.0.3-beta.1",
+  "version": "0.0.3",
   "files": [
     "/dist",
     "/src"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "dist/types/tom-select.complete.d.ts",
   "description": "Tom Select is a versatile and dynamic <select> UI control. Forked from Selectize.js to provide a framework agnostic autocomplete widget with native-feeling keyboard navigation, it's useful for tagging, contact lists, country selectors, etc.",
   "homepage": "https://tom-select.js.org",
-  "version": "0.0.2",
+  "version": "0.0.3-beta.1",
   "files": [
     "/dist",
     "/src"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "dist/types/tom-select.complete.d.ts",
   "description": "Tom Select is a versatile and dynamic <select> UI control. Forked from Selectize.js to provide a framework agnostic autocomplete widget with native-feeling keyboard navigation, it's useful for tagging, contact lists, country selectors, etc.",
   "homepage": "https://tom-select.js.org",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "files": [
     "/dist",
     "/src"

--- a/src/tom-select.ts
+++ b/src/tom-select.ts
@@ -1071,6 +1071,26 @@ export default class TomSelect extends MicroPlugin(MicroEvent) {
 			removeClasses(self.wrapper, self.settings.loadingClass);
 		}
 
+		iterate(options, (option: TomOption) => {
+			/**
+			 * If no option exists in the original input for the newly fetched option,
+			 * add it to the DOM and store a reference to that new node on the object
+			 * object.
+			 */
+			if (!option.$option) {
+				const option_el = getDom(
+					'<option value="' +
+						escape_html(option[this.settings.valueField]) +
+						'">' +
+						escape_html(option[this.settings.labelField]) +
+						'</option>'
+				) as HTMLOptionElement;
+				option.$option = option_el;
+
+				self.input.append(option_el);
+			}
+		});
+
 		self.trigger('load', options, optgroups);
 	}
 


### PR DESCRIPTION
## Context

https://secure.helpscout.net/conversation/2499159955/60820?folderId=6987275

## Summary

When options were lazy loaded into the input, they were not getting added to the original input. This caused an issue with the GPADVS and the limit selection snippet.

