### PR TITLE
Added accessibility improvements for Remove Button.

### DIFF
--- a/src/plugins/remove_button/plugin.ts
+++ b/src/plugins/remove_button/plugin.ts
@@ -26,7 +26,7 @@ export default function (this: TomSelect, userOptions: RBOptions) {
 			title: 'Remove',
 			className: 'remove',
 			append: true,
-			tabindex: '-1',
+			tabindex: '0',
 		},
 		userOptions
 	);

--- a/src/plugins/remove_button/plugin.ts
+++ b/src/plugins/remove_button/plugin.ts
@@ -50,7 +50,6 @@ export default function (this: TomSelect, userOptions: RBOptions) {
 		options.label +
 		'</a>';
 
-
 	self.hook('after', 'setupTemplates', () => {
 		const orig_render_item = self.settings.render.item;
 

--- a/src/plugins/remove_button/plugin.ts
+++ b/src/plugins/remove_button/plugin.ts
@@ -26,6 +26,7 @@ export default function (this: TomSelect, userOptions: RBOptions) {
 			title: 'Remove',
 			className: 'remove',
 			append: true,
+			tabindex: '-1',
 		},
 		userOptions
 	);
@@ -41,11 +42,14 @@ export default function (this: TomSelect, userOptions: RBOptions) {
 	const html =
 		'<a href="javascript:void(0)" class="' +
 		options.className +
-		'" tabindex="-1" title="' +
+		'" tabindex="' +
+		(options.tabindex !== undefined ? options.tabindex : '-1') +  // Use custom tabindex or default to -1.
+		'" title="' +
 		escape_html(options.title) +
 		'">' +
 		options.label +
 		'</a>';
+
 
 	self.hook('after', 'setupTemplates', () => {
 		const orig_render_item = self.settings.render.item;

--- a/src/plugins/remove_button/plugin.ts
+++ b/src/plugins/remove_button/plugin.ts
@@ -42,8 +42,7 @@ export default function (this: TomSelect, userOptions: RBOptions) {
 	const html =
 		'<a href="javascript:void(0)" class="' +
 		options.className +
-		'" tabindex="' +
-		(options.tabindex !== undefined ? options.tabindex : '-1') +  // Use custom tabindex or default to -1.
+		'" tabindex="' + options.tabindex +
 		'" title="' +
 		escape_html(options.title) +
 		'">' +


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2735373133/72735

## Summary

GP Advanced Select is creating accessibility issues due to `tabindex=-1` for the Remove Button

![CleanShot-2024-10-18-at-06-32-42](https://github.com/user-attachments/assets/2a069cb3-984e-4ec7-a87a-53dc13923bd1)

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.