### PR TITLE
Fixed an issue with scrolling when more results were loaded.

### DIFF
--- a/src/plugins/virtual_scroll/plugin.ts
+++ b/src/plugins/virtual_scroll/plugin.ts
@@ -213,7 +213,11 @@ export default function (this: TomSelect) {
 			loading_more = true;
 			self.load.call(self, self.lastValue);
 
-			// Restore scroll position after loading more results.
+			// We use a MutationObserver here to wait until new DOM nodes (i.e., additional results) are inserted into the dropdown before restoring the scroll position.
+			// This helps avoid the jarring UX of the scroll jumping to the top or not reflecting the user's previous position when infinite scrolling is triggered.
+			// The `+10` adjustment is a small buffer to simulate a smooth transition and prevent a perceived "stickiness" at the bottom of the scroll area.
+			// Note: If performance issues arise in the future, we would need to revisit.
+			// Disconnecting the observer immediately after restoring scroll ensures minimal overhead.
 			const observer = new MutationObserver(() => {
 				dropdown_content.scrollTop = scrollTop + 10;
 				observer.disconnect();

--- a/src/plugins/virtual_scroll/plugin.ts
+++ b/src/plugins/virtual_scroll/plugin.ts
@@ -207,8 +207,19 @@ export default function (this: TomSelect) {
 				return;
 			}
 
+			// Save scroll position.
+			const scrollTop = dropdown_content.scrollTop;
+
 			loading_more = true;
 			self.load.call(self, self.lastValue);
+
+			// Restore scroll position after loading more results.
+			const observer = new MutationObserver(() => {
+				dropdown_content.scrollTop = scrollTop + 10;
+				observer.disconnect();
+			});
+
+			observer.observe(dropdown_content, { childList: true, subtree: true });
 		});
 	});
 }


### PR DESCRIPTION
## Context

https://secure.helpscout.net/conversation/2922946919/82775

## Summary
When using GPADVS infinite scroll (enabled via Lazy Load) in combination with GPPA, scrolling too quickly will initiate a request for more choices that scrolls back up after the request is completed and the new choices are populated.

David's loom:
https://www.loom.com/share/d23b36309fa6475e8c9b5b1dfdb46860

My loom with the fix (sort of):
https://www.loom.com/share/1cfac8b29d4d44958afaf1ec83435504