### PR TITLE
Fixed issue with drag and drop plugin where `$` was not defined.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "dist/types/tom-select.complete.d.ts",
   "description": "Tom Select is a versatile and dynamic <select> UI control. Forked from Selectize.js to provide a framework agnostic autocomplete widget with native-feeling keyboard navigation, it's useful for tagging, contact lists, country selectors, etc.",
   "homepage": "https://tom-select.js.org",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "files": [
     "/dist",
     "/src"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@types/jquery": "^3.5.14",
+    "@types/jquery-sortable": "^0.9.34",
     "@types/jqueryui": "^1.12.14",
     "@wordpress/eslint-plugin": "^17.1.0",
     "autoprefixer": "^10.2.4",

--- a/src/plugins/drag_drop/plugin.ts
+++ b/src/plugins/drag_drop/plugin.ts
@@ -1,3 +1,5 @@
+/// <reference types="jquery" />
+
 /**
  * Plugin: "drag_drop" (Tom Select)
  * Copyright (c) contributors
@@ -14,6 +16,19 @@
  */
 
 import TomSelect from '../../tom-select';
+
+// @ts-ignore
+const $ = window.jQuery;
+
+interface JQuerySortableUIArg {
+	helper: JQuery;
+	item: JQuery;
+	offst: { top: number; left: number };
+	position: { top: number; left: number };
+	originalPosition: { top: number; left: number };
+	sender: JQuery;
+	placeholder: JQuery;
+}
 
 export default function (this: TomSelect) {
 	const self = this;
@@ -50,7 +65,7 @@ export default function (this: TomSelect) {
 			items: '[data-value]',
 			forcePlaceholderSize: true,
 			disabled: self.isLocked,
-			start: (e, ui) => {
+			start: (e: JQuery.Event, ui: JQuerySortableUIArg) => {
 				ui.placeholder.css('width', ui.helper.css('width'));
 				$control.css({ overflow: 'visible' });
 			},

--- a/test/html/bootstrap.bundle.js
+++ b/test/html/bootstrap.bundle.js
@@ -318,7 +318,7 @@
 	const reflow = (element) => element.offsetHeight;
 
 	const getjQuery = () => {
-		const { jQuery } = window;
+		const jQuery = require('jquery');
 
 		if (jQuery && !document.body.hasAttribute('data-bs-no-jquery')) {
 			return jQuery;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,6 +1929,13 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz"
   integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
 
+"@types/jquery-sortable@^0.9.34":
+  version "0.9.34"
+  resolved "https://registry.yarnpkg.com/@types/jquery-sortable/-/jquery-sortable-0.9.34.tgz#5efb514929e5fc6c76aab6101b765f97a40ebc8b"
+  integrity sha512-ROzllrc749ikY+Dai75dxI2GY6vl4JQZR51gIMMxHVYf/GQ/tR4JTtus1c3Uv9icogcYOFOywy6dJWglF6X1dA==
+  dependencies:
+    "@types/jquery" "*"
+
 "@types/jquery@*", "@types/jquery@^3.5.14":
   version "3.5.16"
   resolved "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.16.tgz"


### PR DESCRIPTION
## Context

https://secure.helpscout.net/conversation/2977271468/85589?viewId=8614371

## Summary

`$` was not defined in the drag and drop plugin. Simply adds an alias for that!


